### PR TITLE
Fix midi format

### DIFF
--- a/lib/jsmidgen.js
+++ b/lib/jsmidgen.js
@@ -393,8 +393,15 @@ var Midi = {};
 		var trackCount = this.tracks.length.toString(16);
 
 		// prepare the file header
-		var bytes = File.HDR_CHUNKID + File.HDR_CHUNK_SIZE + File.HDR_TYPE0;
+		var bytes = File.HDR_CHUNKID + File.HDR_CHUNK_SIZE;
 
+		// set Midi type based on number of tracks
+		if (trackCount > 1) {
+			bytes += File.HDR_TYPE1;
+		} else {
+			bytes += File.HDR_TYPE0;
+		}
+		
 		// add the number of tracks (2 bytes)
 		bytes += Util.codes2Str(Util.str2Bytes(trackCount, 2));
 		// add the number of ticks per beat (currently hardcoded)

--- a/lib/jsmidgen.js
+++ b/lib/jsmidgen.js
@@ -396,7 +396,7 @@ var Midi = {};
 		var bytes = File.HDR_CHUNKID + File.HDR_CHUNK_SIZE;
 
 		// set Midi type based on number of tracks
-		if (parseInt(trackCount) > 1) {
+		if (parseInt(trackCount, 16) > 1) {
 			bytes += File.HDR_TYPE1;
 		} else {
 			bytes += File.HDR_TYPE0;

--- a/lib/jsmidgen.js
+++ b/lib/jsmidgen.js
@@ -396,7 +396,7 @@ var Midi = {};
 		var bytes = File.HDR_CHUNKID + File.HDR_CHUNK_SIZE;
 
 		// set Midi type based on number of tracks
-		if (trackCount > 1) {
+		if (parseInt(trackCount) > 1) {
 			bytes += File.HDR_TYPE1;
 		} else {
 			bytes += File.HDR_TYPE0;


### PR DESCRIPTION
Updated jsmidgen.js so that it sets the format of the MIDI file based on the number of tracks.  The format should be '0' if there is only one track and it should be '1' if there is more than one track.