### PR TITLE
Guard against wrong input to translateTickTime()

### DIFF
--- a/lib/jsmidgen.js
+++ b/lib/jsmidgen.js
@@ -155,6 +155,10 @@ var Midi = {};
 		 * @returns {number} Array of bytes that form the MIDI time value.
 		 */
 		translateTickTime: function(ticks) {
+			if (ticks < 0) {
+				throw new Error('Number of ticks must be non-negative');
+			}
+
 			var buffer = ticks & 0x7F;
 
 			while (ticks = ticks >> 7) {


### PR DESCRIPTION
As raised in https://github.com/dingram/jsmidgen/issues/33, I propose to introduce a check for negative values for the `ticks` argument of `translateTickTime()`. 

Fixes https://github.com/dingram/jsmidgen/issues/33